### PR TITLE
Feature/#47 랜덤 아이템 모달 남은 퀴즈 및 남은 중복 세션 유지 시간 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "javascript-time-ago": "^2.5.7",
         "jwt-decode": "^3.1.2",
         "react": "^18.2.0",
+        "react-countdown": "^2.3.5",
         "react-dom": "^18.2.0",
         "react-lottie-player": "^1.4.3",
         "react-modal": "^3.15.1",
@@ -14943,6 +14944,18 @@
         "node": ">=14"
       }
     },
+    "node_modules/react-countdown": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/react-countdown/-/react-countdown-2.3.5.tgz",
+      "integrity": "sha512-K26ENYEesMfPxhRRtm1r+Pf70SErrvW3g4CArLi/x6MPFjgfDFYePT4UghEj8p2nI0cqVV7/JjDgjyr//U60Og==",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": ">= 15",
+        "react-dom": ">= 15"
+      }
+    },
     "node_modules/react-dev-utils": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
@@ -29104,6 +29117,14 @@
         "raf": "^3.4.1",
         "regenerator-runtime": "^0.13.9",
         "whatwg-fetch": "^3.6.2"
+      }
+    },
+    "react-countdown": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/react-countdown/-/react-countdown-2.3.5.tgz",
+      "integrity": "sha512-K26ENYEesMfPxhRRtm1r+Pf70SErrvW3g4CArLi/x6MPFjgfDFYePT4UghEj8p2nI0cqVV7/JjDgjyr//U60Og==",
+      "requires": {
+        "prop-types": "^15.7.2"
       }
     },
     "react-dev-utils": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "javascript-time-ago": "^2.5.7",
     "jwt-decode": "^3.1.2",
     "react": "^18.2.0",
+    "react-countdown": "^2.3.5",
     "react-dom": "^18.2.0",
     "react-lottie-player": "^1.4.3",
     "react-modal": "^3.15.1",

--- a/src/components/Timer/index.tsx
+++ b/src/components/Timer/index.tsx
@@ -1,0 +1,22 @@
+import Countdown from 'react-countdown';
+import { CountdownRendererFn, CountdownRenderProps } from 'react-countdown/dist/Countdown';
+
+const renderer: CountdownRendererFn = ({ formatted }: CountdownRenderProps) => {
+  return (
+    <span>
+      {formatted.minutes}:{formatted.seconds}
+    </span>
+  );
+};
+
+interface IProps {
+  date: number;
+}
+
+export const Timer = ({ date }: IProps) => {
+  return (
+    <p>
+      <Countdown date={date} renderer={renderer} />
+    </p>
+  );
+};

--- a/src/pages/Space/RandomQModal/index.tsx
+++ b/src/pages/Space/RandomQModal/index.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import { getRandomSpaceItem } from 'service/items';
 import { useLogout } from 'hooks/useLogout';
-import { IItem } from 'types/item';
+import { IRandomItem } from 'types/item';
 import { ISpace } from 'types/space';
 
 import ToastViewer from 'components/ToastUI/Viewer';
@@ -12,6 +12,7 @@ import { StartLottie } from 'components/Lotties/StartLottie';
 import { TitleQuestion } from 'assets/svgs';
 import cx from 'classnames';
 import cs from './randomQModal.module.scss';
+import { Timer } from '../../../components/Timer';
 
 interface Props {
   useModal: { isOpen: boolean; openModal: () => void; closeModal: (handler: Function) => void };
@@ -21,7 +22,7 @@ interface Props {
 export const RandomQModal = ({ useModal, space }: Props) => {
   const [startState, setStartState] = useState(false);
   const [showState, setShowState] = useState(true);
-  const [quiz, setQuiz] = useState<IItem>({} as IItem);
+  const [quiz, setQuiz] = useState<IRandomItem>({} as IRandomItem);
 
   const { isOpen, closeModal } = useModal;
   const closeModalHandler = () => setStartState(false);
@@ -41,8 +42,19 @@ export const RandomQModal = ({ useModal, space }: Props) => {
     return (
       <ModalTemplate isOpen={isOpen} closeModal={() => closeModal(closeModalHandler)} portalClassName='randomQuestion'>
         <div className={cx(cs.container, cs.beforeStart)}>
-          <div>{space.title}</div>
-          <small className={cs.tip}>(스페이스에 존재하는 모든 문제가 중복없이 랜덤으로 출제됩니다.)</small>
+          <p className={cs.title}>{space.title}</p>
+          <ul className={cs.noticeList}>
+            <li>
+              스페이스에 존재하는 모든 문제가 <mark>중복없이 랜덤으로 출제</mark>됩니다.
+            </li>
+            <li>
+              오른쪽 상단에는 <mark>중복 없이</mark> 문제를 뽑을 수 있는 <mark>시간</mark>이 존재합니다.
+            </li>
+            <li>
+              시간은 <mark>문제를 뽑을 때 마다 초기화</mark> 됩니다.
+            </li>
+            <li>실수로 창을 닫아도 해당 시간 내에는 유지됩니다.</li>
+          </ul>
           <StartLottie />
           <button className={cs.startButton} type='button' onClick={getRandomQuiz}>
             시작하기
@@ -54,23 +66,32 @@ export const RandomQModal = ({ useModal, space }: Props) => {
   return (
     <ModalTemplate isOpen={isOpen} closeModal={() => closeModal(closeModalHandler)} portalClassName='randomQuestion'>
       <div className={cs.container}>
+        <div className={cs.statusWrapper}>
+          <div className={cs.remainingWord}>
+            <p>남은 문제</p>
+            <p>{quiz.remainingWordCnt}개</p>
+          </div>
+          <div className={cs.remainingExpiredTime}>
+            남은 시간 <Timer date={Date.now() + quiz.remainingExpireTime} />
+          </div>
+        </div>
         {showState && (
           <div className={cs.questionWrapper}>
             <div className={cs.question}>
               <TitleQuestion />
-              <span>{quiz.question}</span>
+              <span>{quiz.itemResponse.question}</span>
             </div>
           </div>
         )}
         {!showState && (
           <div className={cs.answer}>
-            <ToastViewer content={quiz.answer} />
+            <ToastViewer content={quiz.itemResponse.answer} />
           </div>
         )}
         <div className={cs.bottom}>
           <ul className={cs.hintList}>
-            {quiz.hint.length !== 0 &&
-              quiz.hint.split(',').map((hint) => (
+            {quiz.itemResponse.hint.length !== 0 &&
+              quiz.itemResponse.hint.split(',').map((hint) => (
                 <li key={hint} className={cs.hint}>
                   {hint}
                 </li>

--- a/src/pages/Space/RandomQModal/randomQModal.module.scss
+++ b/src/pages/Space/RandomQModal/randomQModal.module.scss
@@ -21,6 +21,49 @@
     width: 40vw;
   }
 
+  .title {
+    font-size: 22px;
+    font-weight: 500;
+  }
+
+  .noticeList {
+    margin-top: 12px;
+    font-size: 8px;
+
+    @include responsive.after('SD') {
+      font-size: 14px;
+    }
+
+    li {
+      margin: 6px 0;
+
+      &::before {
+        color: colors.$THEME;
+        content: '✲ ';
+      }
+
+      mark {
+        font-weight: bold;
+        background: transparent;
+      }
+    }
+  }
+
+  .statusWrapper {
+    display: flex;
+    width: 100%;
+
+    .remainingWord {
+      margin-left: auto;
+      text-align: center;
+    }
+
+    .remainingExpiredTime {
+      margin-left: auto;
+      text-align: center;
+    }
+  }
+
   .questionWrapper {
     display: flex;
     align-items: center;

--- a/src/types/item.d.ts
+++ b/src/types/item.d.ts
@@ -9,3 +9,9 @@ export interface IItem {
   createdAt: string;
   spaceMemberResponse: ISpaceMember;
 }
+
+export interface IRandomItem {
+  remainingWordCnt: number;
+  remainingExpireTime: number;
+  itemResponse: IItem;
+}


### PR DESCRIPTION
#47 

### 랜덤 질문 모달 첫 공지 일부 변경
<img width="778" alt="image" src="https://user-images.githubusercontent.com/64524916/210078924-2f6b6e71-6e33-416d-9446-3a8eea86299f.png">

### 랜덤 질문 뽑을 시, 노출 데이터 추가
1. 남은 문제 수
2. 남은 중복 방지 세션 시간
<img width="763" alt="image" src="https://user-images.githubusercontent.com/64524916/210079048-3bf4b334-3b19-481b-b3e4-c5bc63fe2fc7.png">

---
스타일 작업은 진행하지 않았음.
추후 다른 이슈를 만들어 다른 부분과 함께 진행 예정